### PR TITLE
Break out of correct loop

### DIFF
--- a/pkg/delivery/delivery.go
+++ b/pkg/delivery/delivery.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/xmtp/example-notification-server-go/pkg/interfaces"
 	"go.uber.org/zap"
@@ -25,13 +26,14 @@ func NewDeliveryService(logger *zap.Logger, apns *ApnsDelivery, fcm *FcmDelivery
 func (d DefaultDeliveryService) Send(ctx context.Context, req interfaces.SendRequest) error {
 	d.logger.Info("Sending notification", zap.Any("req", req))
 	var err error
+	encodedMessage := base64.StdEncoding.EncodeToString(req.Message.Message)
 	for _, installation := range req.Installations {
 		if installation.DeliveryMechanism.Kind == interfaces.APNS && d.apns != nil {
 			// TODO: Better error handling for cases where one message succeeds and another fails
-			err = d.apns.Send(ctx, installation.DeliveryMechanism.Token, req.Message.GetContentTopic(), string(req.Message.Message))
+			err = d.apns.Send(ctx, installation.DeliveryMechanism.Token, req.Message.GetContentTopic(), encodedMessage)
 		}
 		if installation.DeliveryMechanism.Kind == interfaces.FCM && d.fcm != nil {
-			err = d.fcm.Send(ctx, installation.DeliveryMechanism.Token, req.Message.GetContentTopic(), string(req.Message.Message))
+			err = d.fcm.Send(ctx, installation.DeliveryMechanism.Token, req.Message.GetContentTopic(), encodedMessage)
 		}
 		if err != nil {
 			break

--- a/pkg/delivery/fcm.go
+++ b/pkg/delivery/fcm.go
@@ -44,8 +44,6 @@ func NewFcmDelivery(ctx context.Context, logger *zap.Logger, opts options.FcmOpt
 }
 
 func (f *FcmDelivery) Send(ctx context.Context, token, topic, message string) error {
-	title := "New message from XMTP"
-	body := "Open app to read"
 	data := map[string]string{
 		"topic":            topic,
 		"encryptedMessage": message,
@@ -54,18 +52,15 @@ func (f *FcmDelivery) Send(ctx context.Context, token, topic, message string) er
 	_, err := f.client.Send(ctx, &messaging.Message{
 		Token: token,
 		Data:  data,
-		Notification: &messaging.Notification{
-			Title: title,
-			Body:  body,
-		},
 		Android: &messaging.AndroidConfig{
-			Notification: &messaging.AndroidNotification{
-				Title: title,
-				Body:  body,
-			},
-			Data: data,
+			Data:     data,
+			Priority: "high",
 		},
 		APNS: &messaging.APNSConfig{
+			Headers: map[string]string{
+				"apns-push-type": "background",
+				"apns-priority":  "5",
+			},
 			Payload: &messaging.APNSPayload{
 				CustomData: map[string]interface {
 				}{
@@ -73,11 +68,7 @@ func (f *FcmDelivery) Send(ctx context.Context, token, topic, message string) er
 					"encryptedMessage": message,
 				},
 				Aps: &messaging.Aps{
-					Alert: &messaging.ApsAlert{
-						Title: title,
-						Body:  body,
-					},
-					MutableContent: true,
+					ContentAvailable: true,
 				},
 			},
 		},

--- a/pkg/subscriptions/subscriptions.go
+++ b/pkg/subscriptions/subscriptions.go
@@ -82,11 +82,11 @@ func (s SubscriptionsService) Unsubscribe(ctx context.Context, installationId st
 
 func (s SubscriptionsService) GetSubscriptions(ctx context.Context, topic string) (out []interfaces.Subscription, err error) {
 	results := make([]db.Subscription, 0)
-	_, err = s.db.NewSelect().
+	err = s.db.NewSelect().
 		Model(&results).
 		Where("topic = ?", topic).
-		Where("is_active = ?", true).
-		Exec(ctx)
+		Where("is_active = TRUE").
+		Scan(ctx)
 
 	if err != nil {
 		return nil, err

--- a/pkg/subscriptions/subscriptions_test.go
+++ b/pkg/subscriptions/subscriptions_test.go
@@ -131,3 +131,18 @@ func Test_UnsubscribeResubscribe(t *testing.T) {
 	require.Equal(t, stored.InstallationId, INSTALLATION_ID)
 	require.True(t, stored.IsActive)
 }
+
+func Test_GetSubscriptions(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup := test.CreateTestDb()
+	defer cleanup()
+
+	svc := createService(db)
+
+	err := svc.Subscribe(ctx, INSTALLATION_ID, []string{TOPIC})
+	require.NoError(t, err)
+
+	subs, err := svc.GetSubscriptions(ctx, TOPIC)
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+}

--- a/pkg/xmtp/listener.go
+++ b/pkg/xmtp/listener.go
@@ -75,7 +75,7 @@ func (l *Listener) startMessageListener() {
 			time.Sleep(3 * time.Second)
 			continue
 		}
-	StreamLoop:
+	streamLoop:
 		for {
 			select {
 			case <-l.ctx.Done():
@@ -85,12 +85,12 @@ func (l *Listener) startMessageListener() {
 				msg, err := stream.Recv()
 				if err == io.EOF {
 					l.logger.Info("stream closed")
-					break StreamLoop
+					break streamLoop
 				}
 
 				if err != nil {
 					l.logger.Error("error reading from stream", zap.Error(err))
-					break StreamLoop
+					break streamLoop
 				}
 
 				if msg != nil {

--- a/pkg/xmtp/listener.go
+++ b/pkg/xmtp/listener.go
@@ -75,6 +75,7 @@ func (l *Listener) startMessageListener() {
 			time.Sleep(3 * time.Second)
 			continue
 		}
+	StreamLoop:
 		for {
 			select {
 			case <-l.ctx.Done():
@@ -84,12 +85,12 @@ func (l *Listener) startMessageListener() {
 				msg, err := stream.Recv()
 				if err == io.EOF {
 					l.logger.Info("stream closed")
-					break
+					break StreamLoop
 				}
 
 				if err != nil {
 					l.logger.Error("error reading from stream", zap.Error(err))
-					break
+					break StreamLoop
 				}
 
 				if msg != nil {
@@ -142,6 +143,7 @@ func (l *Listener) processEnvelope(env *v1.Envelope) error {
 	}
 
 	if len(installations) == 0 {
+		l.logger.Info("No matching installations found for topic", zap.String("topic", env.ContentTopic))
 		return nil
 	}
 

--- a/pkg/xmtp/listener.go
+++ b/pkg/xmtp/listener.go
@@ -129,6 +129,7 @@ func (l *Listener) processEnvelope(env *v1.Envelope) error {
 	}
 
 	if len(subs) == 0 {
+		l.logger.Info("no subscriptions for topic", zap.String("topic", env.ContentTopic))
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

I realized that once the notifications listener has an issue with a stream, it will fail indefinitely. Looks like this is related to not resetting the connection.

Also fixes a bug in the query for subscriptions