### PR TITLE
Demonstrate how to just log the message

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Example push notification server, written in Golang
 
 ![Status](https://camo.githubusercontent.com/47c9762c88d56b96ffa436e2af994dab07f6f61f2a0388cd08be7d42b1b8fef5/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f50726f6a6563745f5374617475732d446576656c6f7065725f507265766965772d79656c6c6f77)
 
-This project is in Developer Preview status and ready to serve as a reference for you to start building. 
+This project is in Developer Preview status and ready to serve as a reference for you to start building.
 
 However, we do NOT recommend using Developer Preview software in production apps. Software in this status may change based on feedback.
 
@@ -52,13 +52,23 @@ source .env
 ./dev/run --xmtp-listener --api
 ```
 
+### Running the listener and just logging the message
+
+If you want to just log the message received from the listener and nothing more, use this branch and do the following:
+
+````sh
+./dev/up
+source .env
+./dev/run --xmtp-listener
+```
+
 ### Command line options
 
 To see a full list of command line options run
 
 ```sh
 ./dev/run --help
-```
+````
 
 Here is the output as of 21/12/2021:
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,25 +69,26 @@ func main() {
 	var apiServer *api.ApiServer
 
 	if opts.Xmtp.ListenerEnabled {
-		var apns *delivery.ApnsDelivery
-		var fcm *delivery.FcmDelivery
+		// var apns *delivery.ApnsDelivery
+		// var fcm *delivery.FcmDelivery
 		var err error
 
-		if opts.Apns.Enabled {
-			apns, err = delivery.NewApnsDelivery(logger, opts.Apns)
-			if err != nil {
-				logger.Fatal("failed to initialize APNS", zap.Error(err))
-			}
-		}
+		// if opts.Apns.Enabled {
+		// 	apns, err = delivery.NewApnsDelivery(logger, opts.Apns)
+		// 	if err != nil {
+		// 		logger.Fatal("failed to initialize APNS", zap.Error(err))
+		// 	}
+		// }
 
-		if opts.Fcm.Enabled {
-			fcm, err = delivery.NewFcmDelivery(ctx, logger, opts.Fcm)
-			if err != nil {
-				logger.Fatal("failed to initialize FCM", zap.Error(err))
-			}
-		}
+		// if opts.Fcm.Enabled {
+		// 	fcm, err = delivery.NewFcmDelivery(ctx, logger, opts.Fcm)
+		// 	if err != nil {
+		// 		logger.Fatal("failed to initialize FCM", zap.Error(err))
+		// 	}
+		// }
 
-		deliveryService := delivery.NewDeliveryService(logger, apns, fcm)
+		// deliveryService := delivery.NewDeliveryService(logger, apns, fcm)
+		deliveryService := delivery.NewLoggingDelivery(logger)
 		listener, err = xmtp.NewListener(ctx, logger, opts.Xmtp, installationsService, subscriptionsService, deliveryService, clientVersion, appVersion)
 		if err != nil {
 			logger.Fatal("failed to initialize listener", zap.Error(err))

--- a/pkg/delivery/log.go
+++ b/pkg/delivery/log.go
@@ -1,0 +1,27 @@
+package delivery
+
+import (
+	"context"
+
+	"github.com/xmtp/example-notification-server-go/pkg/interfaces"
+	"go.uber.org/zap"
+)
+
+type LoggingDelivery struct {
+	logger *zap.Logger
+}
+
+func NewLoggingDelivery(logger *zap.Logger) *LoggingDelivery {
+	return &LoggingDelivery{logger: logger}
+}
+
+func (l LoggingDelivery) Send(ctx context.Context, req interfaces.SendRequest) error {
+	if req.Message == nil {
+		return nil
+	}
+	l.logger.Info("message received",
+		zap.String("content_topic", req.Message.ContentTopic),
+		zap.String("message", string(req.Message.Message)),
+	)
+	return nil
+}


### PR DESCRIPTION
## Summary

I whipped up this PR as a quick example of how to run the XMTP listener and just log the message.

It comments out the regular Delivery Service and replaces it with one that doesn't actually send Push Notifications but just logs instead. Can be used for quickly validating that the listener is working.

The next step from here would be to create your own delivery service that proxies requests to another service.

## Notes
Do not merge. Just for demo purposes. 