### PR TITLE
Fix bug with delete and re-register

### DIFF
--- a/pkg/installations/installations.go
+++ b/pkg/installations/installations.go
@@ -30,7 +30,8 @@ func (s DefaultInstallationService) Register(ctx context.Context, installation i
 			Model(&db.Installation{
 				Id: installation.Id,
 			}).
-			Ignore().
+			On("CONFLICT(id) DO UPDATE").
+			Set("deleted_at = NULL").
 			Exec(ctx)
 
 		if err != nil {

--- a/pkg/installations/installations_test.go
+++ b/pkg/installations/installations_test.go
@@ -162,6 +162,33 @@ func Test_Delete(t *testing.T) {
 	require.NotNil(t, install.DeletedAt)
 }
 
+func Test_DeleteAndRegisterAgain(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup := test.CreateTestDb()
+	defer cleanup()
+	svc := createService(db)
+
+	createReq := buildInstallation(INSTALLATION_ID, interfaces.APNS, TOKEN)
+	_, err := svc.Register(ctx, createReq)
+
+	require.NoError(t, err)
+
+	err = svc.Delete(ctx, INSTALLATION_ID)
+	require.NoError(t, err)
+
+	_, err = svc.Register(ctx, createReq)
+	require.NoError(t, err)
+
+	install := new(database.Installation)
+	err = db.NewSelect().
+		Model(install).
+		Where("id = ?", INSTALLATION_ID).
+		Scan(ctx)
+
+	require.NoError(t, err)
+	require.Nil(t, install.DeletedAt)
+}
+
 func Test_Get(t *testing.T) {
 	ctx := context.Background()
 	db, _ := test.CreateTestDb()


### PR DESCRIPTION
## Summary

There is a bug in the service that can be reproduced by doing the following

1. Register an installation with `install_id_1`
2. Delete the installation
3. Attempt to register `install_id_1` again

The expected behaviour is that the installation is no longer marked as deleted.

The current behaviour is that the installation remains deleted even after re-registration.