### PR TITLE
Fix p8 cert for APNS

### DIFF
--- a/pkg/delivery/apns.go
+++ b/pkg/delivery/apns.go
@@ -20,10 +20,17 @@ type ApnsDelivery struct {
 }
 
 func NewApnsDelivery(logger *zap.Logger, opts options.ApnsOptions) (*ApnsDelivery, error) {
-	bytes, err := ioutil.ReadFile(opts.P8Certificate)
-	
-	if err != nil {
-		return nil, err
+	var bytes []byte
+	var err error
+
+	if opts.P8Certificate == "" {
+		bytes, err = ioutil.ReadFile(opts.P8CertificateFilePath)
+
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		bytes = []byte(opts.P8Certificate)
 	}
 
 	client, err := getApnsClient(bytes, opts.KeyId, opts.TeamId)

--- a/pkg/delivery/apns.go
+++ b/pkg/delivery/apns.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"ioutil"
 	"time"
 
 	"github.com/sideshow/apns2"

--- a/pkg/delivery/apns.go
+++ b/pkg/delivery/apns.go
@@ -19,7 +19,14 @@ type ApnsDelivery struct {
 }
 
 func NewApnsDelivery(logger *zap.Logger, opts options.ApnsOptions) (*ApnsDelivery, error) {
-	client, err := getApnsClient([]byte(opts.P8Certificate), opts.KeyId, opts.TeamId)
+	bytes, err := ioutil.ReadFile(opts.P8Certificate)
+	
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := getApnsClient(bytes, opts.KeyId, opts.TeamId)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/delivery/apns.go
+++ b/pkg/delivery/apns.go
@@ -2,7 +2,7 @@ package delivery
 
 import (
 	"context"
-	"ioutil"
+	"io/ioutil"
 	"time"
 
 	"github.com/sideshow/apns2"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -6,11 +6,12 @@ type ApiOptions struct {
 }
 
 type ApnsOptions struct {
-	Enabled       bool   `long:"apns-enabled" env:"APNS_ENABLED" description:"Enable APNS"`
-	P8Certificate string `long:"apns-p8-certificate" env:"APNS_P8_CERTIFICATE" description:".p8 certificate for APNS"`
-	KeyId         string `long:"apns-key-id" env:"APNS_KEY_ID" description:"Key ID associated with APNS credentials"`
-	TeamId        string `long:"apns-team-id" env:"APNS_TEAM_ID" description:"APNS Team ID"`
-	Topic         string `long:"apns-topic" env:"APNS_TOPIC" description:"Topic to be used on all messages"`
+	Enabled               bool   `long:"apns-enabled" env:"APNS_ENABLED" description:"Enable APNS"`
+	P8Certificate         string `long:"apns-p8-certificate" env:"APNS_P8_CERTIFICATE" description:".p8 certificate data for APNS"`
+	P8CertificateFilePath string `long:"apns-p8-certificate-file-path" env:"APNS_P8_CERTIFICATE_FILE_PATH" description:".p8 certificate file for APNS"`
+	KeyId                 string `long:"apns-key-id" env:"APNS_KEY_ID" description:"Key ID associated with APNS credentials"`
+	TeamId                string `long:"apns-team-id" env:"APNS_TEAM_ID" description:"APNS Team ID"`
+	Topic                 string `long:"apns-topic" env:"APNS_TOPIC" description:"Topic to be used on all messages"`
 }
 
 type FcmOptions struct {


### PR DESCRIPTION
Previously we were just passing the filename from the `--apns-p8-certificate` option as the key data. This PR fixes that.