### PR TITLE
Setup automatic deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,19 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Deploy
+      - name: Push
+        id: push
         run: |
           export DOCKER_IMAGE_TAG=latest
           IMAGE_TO_DEPLOY=xmtp/notifications-server@$(dev/push)
-          echo Successfully pushed $IMAGE_TO_DEPLOY
+          echo "docker_image=${IMAGE_TO_DEPLOY}" >> $GITHUB_OUTPUT
+
+      - name: Deploy to dev
+        uses: xmtp-labs/terraform-deployer@v1
+        with:
+          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
+          terraform-org: xmtp
+          terraform-workspace: dev
+          variable-name: notifications_server_image
+          variable-value: ${{ steps.push.outputs.docker_image }}
+          variable-value-required-prefix: xmtp/notifications-server

--- a/pkg/xmtp/listener.go
+++ b/pkg/xmtp/listener.go
@@ -131,7 +131,6 @@ func (l *Listener) processEnvelope(env *v1.Envelope) error {
 	}
 
 	if len(subs) == 0 {
-		l.logger.Info("no subscriptions for topic", zap.String("topic", env.ContentTopic))
 		return nil
 	}
 
@@ -149,6 +148,8 @@ func (l *Listener) processEnvelope(env *v1.Envelope) error {
 		l.logger.Info("No matching installations found for topic", zap.String("topic", env.ContentTopic))
 		return nil
 	}
+
+	l.logger.Info("active subscription found. sending message", zap.String("topic", env.ContentTopic))
 
 	return l.delivery.Send(
 		l.ctx,


### PR DESCRIPTION
## Summary
- Uses the new deployment Github Action to deploy automatically (right now, just to dev)
- The logging was getting a little noisy, so I switched things around to log less in cases where no notification is sent and a little more when we do send a notification.

## Issues
- https://github.com/xmtp-labs/hq/issues/933