### PR TITLE
Add --apns-mode option to specify which server to send to

### DIFF
--- a/pkg/delivery/apns.go
+++ b/pkg/delivery/apns.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"time"
 
@@ -34,6 +35,14 @@ func NewApnsDelivery(logger *zap.Logger, opts options.ApnsOptions) (*ApnsDeliver
 	}
 
 	client, err := getApnsClient(bytes, opts.KeyId, opts.TeamId)
+
+	if opts.Mode == "production" {
+		client.Production()
+	} else if opts.Mode == "development" {
+		client.Development()
+	} else {
+		return nil, errors.New("invalid APNS mode")
+	}
 
 	if err != nil {
 		return nil, err

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -12,7 +12,7 @@ type ApnsOptions struct {
 	KeyId                 string `long:"apns-key-id" env:"APNS_KEY_ID" description:"Key ID associated with APNS credentials"`
 	TeamId                string `long:"apns-team-id" env:"APNS_TEAM_ID" description:"APNS Team ID"`
 	Topic                 string `long:"apns-topic" env:"APNS_TOPIC" description:"Topic to be used on all messages"`
-	Mode                  string `long:"apns-mode" env:"APNS_MODE" description:"Which APNS servers to deliver to, development or production"`
+	Mode                  string `long:"apns-mode" env:"APNS_MODE" description:"Which APNS servers to deliver to, development or production" choice:"development" choice:"production" default:"development"`
 }
 
 type FcmOptions struct {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -12,6 +12,7 @@ type ApnsOptions struct {
 	KeyId                 string `long:"apns-key-id" env:"APNS_KEY_ID" description:"Key ID associated with APNS credentials"`
 	TeamId                string `long:"apns-team-id" env:"APNS_TEAM_ID" description:"APNS Team ID"`
 	Topic                 string `long:"apns-topic" env:"APNS_TOPIC" description:"Topic to be used on all messages"`
+	Mode                  string `long:"apns-mode" env:"APNS_MODE" description:"Which APNS servers to deliver to, development or production"`
 }
 
 type FcmOptions struct {


### PR DESCRIPTION
We were always sending to development before. Once we start using the production servers, https://github.com/xmtp-labs/xmtp-inbox-ios/issues/58 should be fixed.