### PR TITLE
Better handle downtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - --ws
       - --store
       - --message-db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      - --message-db-reader-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
       - --lightpush
       - --filter
       - --ws-port=9001

--- a/pkg/xmtp/listener.go
+++ b/pkg/xmtp/listener.go
@@ -24,6 +24,8 @@ type Listener struct {
 	installations  interfaces.Installations
 	delivery       interfaces.Delivery
 	subscriptions  interfaces.Subscriptions
+	clientVersion  string
+	appVersion     string
 }
 
 func NewListener(
@@ -53,6 +55,8 @@ func NewListener(
 		installations:  installations,
 		delivery:       delivery,
 		subscriptions:  subscriptions,
+		clientVersion:  clientVersion,
+		appVersion:     appVersion,
 	}, nil
 }
 
@@ -92,6 +96,11 @@ func (l *Listener) startMessageListener() {
 
 				if err != nil {
 					l.logger.Error("error reading from stream", zap.Error(err))
+					// Wait 100ms to avoid hammering the API and getting rate limited
+					time.Sleep(100 * time.Millisecond)
+					if err = l.refreshClient(); err != nil {
+						l.logger.Error("error refreshing client", zap.Error(err))
+					}
 					break streamLoop
 				}
 
@@ -159,6 +168,16 @@ func (l *Listener) processEnvelope(env *v1.Envelope) error {
 			IdempotencyKey: buildIdempotencyKey(env),
 		},
 	)
+}
+
+func (l *Listener) refreshClient() error {
+	client, err := NewClient(l.ctx, l.opts.GrpcAddress, l.opts.UseTls, l.clientVersion, l.appVersion)
+	if err != nil {
+		return err
+	}
+	l.xmtpClient = client
+
+	return nil
 }
 
 func shouldIgnoreTopic(topic string) bool {

--- a/pkg/xmtp/listener.go
+++ b/pkg/xmtp/listener.go
@@ -79,6 +79,9 @@ func (l *Listener) startMessageListener() {
 			l.logger.Error("error connecting to stream", zap.Error(err))
 			// sleep for a few seconds before retrying
 			time.Sleep(3 * time.Second)
+			if err = l.refreshClient(); err != nil {
+				l.logger.Error("error refreshing client", zap.Error(err))
+			}
 			continue
 		}
 	streamLoop:

--- a/pkg/xmtp/listener.go
+++ b/pkg/xmtp/listener.go
@@ -78,7 +78,7 @@ func (l *Listener) startMessageListener() {
 		if err != nil {
 			l.logger.Error("error connecting to stream", zap.Error(err))
 			// sleep for a few seconds before retrying
-			time.Sleep(3 * time.Second)
+			time.Sleep(100 * time.Millisecond)
 			if err = l.refreshClient(); err != nil {
 				l.logger.Error("error refreshing client", zap.Error(err))
 			}


### PR DESCRIPTION
## Summary

During the XMTP incident this morning, the nodes were briefly unavailable. Two undesirable things happened with the notification listener at that time.

1. We continued trying to reconnect so rapidly that the notification server was throttled by the WAF
2. Once the XMTP nodes came back online, the connection was still not restored in the notification server and errors continued

## The fix
When there is an error in the stream other than `io.EOF`, create a new connection to the XMTP node server and wait 100ms before retrying.