### PR TITLE
Fix node startup args

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-export DB_CONNECTION_STRING="postgres://postgres:xmtp@localhost:25432/postgres?sslmode=disable"
-export XMTP_GRPC_ADDRESS="localhost:5556"
-export LOG_ENCODING=console
-export API_PORT="8080"

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,4 @@
+DB_CONNECTION_STRING="postgres://postgres:xmtp@localhost:25432/postgres?sslmode=disable"
+XMTP_GRPC_ADDRESS="localhost:5556"
+LOG_ENCODING=console
+API_PORT="8080"

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ The server can be run using the `./dev/run` script. Both the `worker` (which lis
 ```sh
 ## Only has to be run once
 ./dev/up
-source .env
-./dev/run --xmtp-listener --api
+./dev/start
 ```
 
 ### Command line options

--- a/dev/build
+++ b/dev/build
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh
+#!/bin/bash
+set -eou pipefail
 
 GIT_COMMIT="$(git rev-parse HEAD)"
 XMTP_GO_CLIENT_VERSION="$(go list -json -m all | jq -r '. | select(.Path == "github.com/xmtp/proto") | .Version')"

--- a/dev/down
+++ b/dev/down
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+docker compose down

--- a/dev/down
+++ b/dev/down
@@ -1,3 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
+set -eou pipefail
 
 docker compose down

--- a/dev/gen-proto
+++ b/dev/gen-proto
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+set -eou pipefail
 
 set -e
 

--- a/dev/lint-shellcheck
+++ b/dev/lint-shellcheck
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -e
+#!/bin/bash
+set -eou pipefail
 
 read -ra shellcheck_paths <<< "$(grep -rIzl '^#!' dev)"
 shellcheck "${shellcheck_paths[@]}"

--- a/dev/push
+++ b/dev/push
@@ -1,5 +1,5 @@
-#!/usr/bin/env sh
-set -e
+#!/bin/bash
+set -eou pipefail
 
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-dev}"
 DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-xmtp/notifications-server}"

--- a/dev/run
+++ b/dev/run
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh
+#!/bin/bash
+set -eou pipefail
+set -a; source .env.local; set +a
 
-source .env
 go run ./cmd/server/main.go "$@"

--- a/dev/run
+++ b/dev/run
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 
+source .env
 go run ./cmd/server/main.go "$@"

--- a/dev/start
+++ b/dev/start
@@ -1,3 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
+set -eou pipefail
 
 dev/run --xmtp-listener --api "$@"

--- a/dev/start
+++ b/dev/start
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+dev/run --xmtp-listener --api "$@"

--- a/dev/up
+++ b/dev/up
@@ -1,3 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
+set -eou pipefail
 
 docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,14 @@
 version: '3'
 
 services:
-  waku-node:
+  node:
     image: xmtp/node-go:latest
+    platform: linux/amd64
     command:
       - --ws
-      - --store
+      - --store.enable
       - --store.db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
       - --store.reader-db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
-      - --lightpush
-      - --filter
       - --ws-port=9001
       - --wait-for-db=30s
       - --api.authn.enable


### PR DESCRIPTION
This PR fixes the node startup args to use `--store.enable` instead of `--store`, and removes `--lightpush` and `--filter`.

It also simplifies the start up instructions with `dev/start`, and cleans up the dev scripts a bit.

Fixes https://github.com/xmtp/example-notification-server-go/issues/26