### PR TITLE
Allow users to escape newlines in p8 certs

### DIFF
--- a/pkg/delivery/apns.go
+++ b/pkg/delivery/apns.go
@@ -3,6 +3,7 @@ package delivery
 import (
 	"context"
 	"errors"
+	"strings"
 	"os"
 
 	"github.com/sideshow/apns2"
@@ -30,7 +31,7 @@ func NewApnsDelivery(logger *zap.Logger, opts options.ApnsOptions) (*ApnsDeliver
 			return nil, err
 		}
 	} else {
-		bytes = []byte(opts.P8Certificate)
+		bytes = []byte(strings.ReplaceAll(opts.P8Certificate, "\\n", "\n"))
 	}
 
 	client, err := getApnsClient(bytes, opts.KeyId, opts.TeamId)


### PR DESCRIPTION
When trying to deploy on [fly](fly.io) I was facing an issue with the reading of the apns .p8 cert. 

I couldn't find a good way to securely store the cert so it could be read in the application so that just leaves an env var.

However when you do the naive thing setting `APNS_P8_CERTIFICATE` to the `.p8` file contents the server will fail with an error initing [`client.Production()`](https://github.com/xmtp/example-notification-server-go/blob/main/pkg/delivery/apns.go#L39)

This pr allows the user to set the env by explicitly escaping the newlines:

If the `.p8` cert is
```
"-----BEGIN PRIVATE KEY-----
flkdflkdf...
-----END PRIVATE KEY-----"
```

then you can set the env var as follows

```
APNS_P8_CERTIFICATE="-----BEGIN PRIVATE KEY-----\nflkdflkdf...\n-----END PRIVATE KEY-----"
```

If I am just missing a better way to do this please let me know 🙏 