### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "Go Dev Container",
+  "build": {
+    "context": "..",
+    "dockerfile": "../dev/docker/devcontainer.Dockerfile"
+  },
+  "remoteEnv": {
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+    "HOST_DOCKER_DEV_FOLDER": "${localWorkspaceFolder}/dev/docker"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "go.gopath": "/go",
+        "go.useLanguageServer": true
+      },
+      "extensions": [
+        "golang.go",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "postCreateCommand": "go mod tidy",
+  "forwardPorts": [],
+  "remoteUser": "vscode",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "username": "vscode",
+      "installZsh": true
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false
+    }
+  }
+}

--- a/dev/docker/devcontainer.Dockerfile
+++ b/dev/docker/devcontainer.Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.25
+
+# Install golangci-lint
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6
+
+# Install buf CLI
+RUN go install github.com/bufbuild/buf/cmd/buf@latest
+
+# Add shellcheck and jq
+RUN apt-get update && apt-get install -y \
+    shellcheck \
+    jq


### PR DESCRIPTION
Resolves https://github.com/xmtp/example-notification-server-go/issues/67

## Summary
- Adds `.devcontainer/devcontainer.json` and `dev/docker/devcontainer.Dockerfile` following the [xmtpd devcontainer](https://github.com/xmtp/xmtpd) pattern
- Includes: Go 1.25, golangci-lint v2, buf CLI, gopls (via Go VS Code extension), shellcheck, Docker-in-Docker (non-Moby), and GitHub CLI
- Verified the devcontainer builds successfully using the devcontainer CLI

## What's included
- **Go 1.25** — matches `go.mod`
- **golangci-lint v2** — compatible with the v2 config in `dev/.golangci.yaml`
- **Buf CLI** — for proto generation (`dev/gen-proto`)
- **Gopls** — via the `golang.go` VS Code extension
- **Shellcheck** — for `dev/lint-shellcheck`
- **Docker-in-Docker** (non-Moby) — for `./dev/up` and integration tests
- **GitHub CLI** — for workflow interactions

## Test plan
- [x] `devcontainer build --workspace-folder .` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add VS Code Dev Container configuration for Go development
> - Adds [devcontainer.json](https://github.com/xmtp/example-notification-server-go/pull/68/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686) configuring a VS Code Dev Container with Go language server support, the `golang.go` and `ms-azuretools.vscode-docker` extensions, and `go mod tidy` as a post-create command.
> - Adds [devcontainer.Dockerfile](https://github.com/xmtp/example-notification-server-go/pull/68/files#diff-9d77843ba6c424b81c3b362904ad3b5c2a7cc45f0ff6d9d2c0b4613d087acb3f) based on `golang:1.25`, installing `golangci-lint` v2.1.6, `buf`, `shellcheck`, and `jq`.
> - Enables docker-in-docker (without Moby) and GitHub CLI as Dev Container features, with a `vscode` remote user.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ed7ab5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added containerized development environment configuration to streamline local development with Go tooling and VS Code integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->