### PR TITLE
Add Zed editor config

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,26 @@
+{
+  "languages": {
+    "Go": {
+      "hard_tabs": true,
+      "tab_size": 4,
+      "format_on_save": "on",
+      "formatter": "language_server",
+      "language_servers": ["gopls", "golangci-lint"]
+    }
+  },
+  "lsp": {
+    "golangci-lint": {
+      "initialization_options": {
+        "command": [
+          "golangci-lint",
+          "run",
+          "--config=./dev/.golangci.yaml",
+          "--output.json.path",
+          "stdout",
+          "--show-stats=false",
+          "--output.text.path="
+        ]
+      }
+    }
+  }
+}

--- a/docs/plans/2026-03-24-issue-71-design.md
+++ b/docs/plans/2026-03-24-issue-71-design.md
@@ -1,0 +1,26 @@
+# Design Spec: Add Zed Editor Configuration
+
+**Issue:** https://github.com/xmtp/example-notification-server-go/issues/71
+
+## Requirements
+
+- **REQ-1:** When the project is opened in Zed, the Go language server (gopls) shall be enabled with standard Go formatting (tabs, format-on-save).
+- **REQ-2:** When the project is opened in Zed, golangci-lint diagnostics shall be provided using the project's existing config at `dev/.golangci.yaml`.
+- **REQ-3:** The configuration shall be minimal — only settings required for good Go development results.
+
+## System Design
+
+Add a single file: `.zed/settings.json`
+
+This mirrors the existing `.vscode/settings.json` pattern already in the repo. The config will:
+1. Configure Go language settings (hard tabs, format on save via language server)
+2. Register both `gopls` and `golangci-lint` as language servers for Go
+3. Pass `--config=./dev/.golangci.yaml` to golangci-lint since the config is not in the project root
+4. Use golangci-lint v2 CLI flags (matching the project's `version: "2"` config)
+
+## Testing & Validation
+
+- Verify `.zed/settings.json` is valid JSON
+- Verify golangci-lint flags match v2 syntax
+- Verify config path matches existing `dev/.golangci.yaml`
+- Verify consistency with existing `.vscode/settings.json` approach


### PR DESCRIPTION
Resolves https://github.com/xmtp/example-notification-server-go/issues/71

## Summary

Adds `.zed/settings.json` with minimal configuration for Go development in the Zed editor:

- **gopls** language server for completions, go-to-definition, and formatting (format-on-save)
- **golangci-lint** extension for linting diagnostics using the project's existing config at `dev/.golangci.yaml`
- Go-standard hard tabs with tab size 4
- Uses golangci-lint v2 CLI flags matching the project's `version: "2"` config

This mirrors the existing `.vscode/settings.json` approach already in the repo.

## Test plan

- [ ] Verify `.zed/settings.json` is valid JSON
- [ ] Open project in Zed and confirm gopls provides completions and formatting
- [ ] Confirm golangci-lint diagnostics appear using `dev/.golangci.yaml` rules
- [ ] Verify format-on-save works for Go files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Zed editor config for Go with gopls and golangci-lint
> Adds [.zed/settings.json](https://github.com/xmtp/example-notification-server-go/pull/72/files#diff-abb804d570c3104a261c81b34f0ad1c1d5edb2f62e1318fa5030dbe6ffbdf3d4) to configure the Zed editor for Go development. Sets hard tabs with size 4 and format-on-save via the language server, and registers both `gopls` and `golangci-lint` as language servers. The golangci-lint LSP is configured to use the project's existing `dev/.golangci.yaml` config with v2-style CLI arguments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2364970.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->