### PR TITLE
Allow dev/gen-proto to supply a different proto path

### DIFF
--- a/dev/gen-proto
+++ b/dev/gen-proto
@@ -13,6 +13,8 @@ if [ -n "$(go env GOPATH)" ]; then
     export PATH="${FOUND_GOPATH}/bin:${PATH}"
 fi
 
+PROTO_PATH="${1:-buf.build/xmtp/proto}"
+
 rm -rf ./pkg/proto
 buf generate --template proto/buf.gen.yaml
-buf generate buf.build/xmtp/proto
+buf generate "$PROTO_PATH"


### PR DESCRIPTION
Resolves https://github.com/xmtp/example-notification-server-go/issues/73

## Summary

- `dev/gen-proto` now accepts an optional positional argument for the proto path
- Falls back to the default `buf.build/xmtp/proto` when no argument is provided

## Usage

```bash
# Default behavior (unchanged)
./dev/gen-proto

# Custom proto path
./dev/gen-proto buf.build/other/proto
```

## Test plan

- [ ] Run `./dev/gen-proto` with no arguments — should behave identically to before
- [ ] Run `./dev/gen-proto <custom-path>` — should use the provided path instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `dev/gen-proto` to accept a custom proto source path argument
> Adds a `PROTO_PATH` variable to [dev/gen-proto](https://github.com/xmtp/example-notification-server-go/pull/75/files#diff-5c2526eba6ab39757155d58129652c363bc7525ba225fd559cda5cad863053c0) that reads the first positional argument, defaulting to `buf.build/xmtp/proto`. The `buf generate` call now uses this variable instead of the hardcoded path, so a different proto source can be passed at the command line without modifying the script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70a12fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->