### PR TITLE
Fix devcontainer postCreateCommand GOPATH permissions

### DIFF
--- a/dev/docker/devcontainer.Dockerfile
+++ b/dev/docker/devcontainer.Dockerfile
@@ -10,3 +10,7 @@ RUN go install github.com/bufbuild/buf/cmd/buf@latest
 RUN apt-get update && apt-get install -y \
     shellcheck \
     jq
+
+# Ensure GOPATH is writable by the vscode user (UID 1000) so that
+# postCreateCommand ("go mod tidy") can populate the module cache.
+RUN chown -R 1000:1000 /go


### PR DESCRIPTION
Resolves https://github.com/xmtp/example-notification-server-go/issues/76

## Summary

- The `postCreateCommand` (`go mod tidy`) was failing because `/go/pkg/mod/cache` is owned by root, but the command runs as the `vscode` user (UID 1000)
- Added `RUN chown -R 1000:1000 /go` to the devcontainer Dockerfile so the vscode user can write to the Go module cache

## Test plan

- [ ] Rebuild the devcontainer from scratch and verify `postCreateCommand` completes without errors
- [ ] Verify `go mod tidy` works inside the container as the vscode user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix /go directory ownership in devcontainer to allow GOPATH writes
> Adds a `chown` step in [devcontainer.Dockerfile](https://github.com/xmtp/example-notification-server-go/pull/79/files#diff-9d77843ba6c424b81c3b362904ad3b5c2a7cc45f0ff6d9d2c0b4613d087acb3f) to set ownership of `/go` to UID/GID 1000, fixing permission errors when the `postCreateCommand` writes to GOPATH inside the container.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c54146.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->