### PR TITLE
Skip Docker image push on fork PRs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to the container registry
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -30,7 +31,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Resolves https://github.com/xmtp/example-notification-server-go/issues/81

## Summary

- Add conditional to skip registry login on fork PRs (no credentials available)
- Change `push: true` to a dynamic expression that only pushes when permissions exist (same-repo PRs or pushes to main)
- Fork PRs still **build** the Docker image, validating the Dockerfile without attempting to push

## Changes

Single file change in `.github/workflows/push.yml`:
- `docker/login-action` step gets `if:` guard for non-fork context
- `docker/build-push-action` `push:` field uses expression to evaluate push permission

## Test plan

- [ ] Fork PR workflow runs: should build successfully without pushing
- [ ] Same-repo PR workflow runs: should build and push as before
- [ ] Push to main: should build and push as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip Docker image login and push on fork PRs
> In [push.yml](.github/workflows/push.yml), the registry login step and the `docker/build-push-action` push input are now conditional, running only on `push` events or PRs from the same repository. Fork PRs skip both steps entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d18d08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->