### PR TITLE
feat: change v4 payload topic to v3 format, add topicBytes field

### DIFF
--- a/pkg/delivery/apns.go
+++ b/pkg/delivery/apns.go
@@ -82,8 +82,8 @@ func (a ApnsDelivery) buildNotification(req interfaces.SendRequest) *apns2.Notif
 		Custom("messageKind", string(req.MessageContext.MessageType)).
 		Custom("payloadFormat", req.PayloadFormat.String())
 
-	if req.TopicBytes != "" {
-		notificationPayload = notificationPayload.Custom("topicBytesB64", req.TopicBytes)
+	if req.TopicBytesB64 != "" {
+		notificationPayload = notificationPayload.Custom("topicBytesB64", req.TopicBytesB64)
 	}
 
 	if req.Subscription.IsSilent {

--- a/pkg/delivery/apns.go
+++ b/pkg/delivery/apns.go
@@ -82,6 +82,10 @@ func (a ApnsDelivery) buildNotification(req interfaces.SendRequest) *apns2.Notif
 		Custom("messageKind", string(req.MessageContext.MessageType)).
 		Custom("payloadFormat", req.PayloadFormat.String())
 
+	if req.TopicBytes != "" {
+		notificationPayload = notificationPayload.Custom("topicBytesB64", req.TopicBytes)
+	}
+
 	if req.Subscription.IsSilent {
 		notificationPayload = notificationPayload.ContentAvailable()
 	} else {

--- a/pkg/delivery/apns_test.go
+++ b/pkg/delivery/apns_test.go
@@ -19,7 +19,7 @@ func buildDeliveryRequest(t *testing.T, payloadFormat interfaces.PayloadFormat) 
 	parsed, err := topics.ParseV3Topic(deliveryTestTopic)
 	require.NoError(t, err)
 	topicStr := topics.TopicToString(parsed)
-	return interfaces.SendRequest{
+	req := interfaces.SendRequest{
 		Topic:            topicStr,
 		EncryptedMessage: []byte("test"),
 		PayloadFormat:    payloadFormat,
@@ -32,6 +32,10 @@ func buildDeliveryRequest(t *testing.T, payloadFormat interfaces.PayloadFormat) 
 		},
 		MessageContext: interfaces.MessageContext{MessageType: topics.V3Conversation},
 	}
+	if payloadFormat == interfaces.PayloadFormatV4 {
+		req.TopicBytes = topics.TopicToBase64(parsed)
+	}
+	return req
 }
 
 func TestApns_PayloadIncludesPayloadFormat(t *testing.T) {
@@ -61,4 +65,19 @@ func Test_ApnsDelivery_BuildNotification_TopicField(t *testing.T) {
 	require.NotContains(t, p, "topicBytesB64")
 	require.Equal(t, "device-token", notification.DeviceToken)
 	require.Equal(t, "com.example.app", notification.Topic)
+}
+
+func Test_ApnsDelivery_BuildNotification_V4TopicBytesB64(t *testing.T) {
+	a := ApnsDelivery{opts: options.ApnsOptions{Topic: "com.example.app"}}
+	req := buildDeliveryRequest(t, interfaces.PayloadFormatV4)
+
+	notification := a.buildNotification(req)
+	payloadBytes, err := notification.Payload.(*payload.Payload).MarshalJSON()
+	require.NoError(t, err)
+
+	var p map[string]interface{}
+	require.NoError(t, json.Unmarshal(payloadBytes, &p))
+	require.Equal(t, deliveryTestTopic, p["topic"])
+	require.Equal(t, req.TopicBytes, p["topicBytesB64"])
+	require.Equal(t, "v4", p["payloadFormat"])
 }

--- a/pkg/delivery/apns_test.go
+++ b/pkg/delivery/apns_test.go
@@ -33,7 +33,7 @@ func buildDeliveryRequest(t *testing.T, payloadFormat interfaces.PayloadFormat) 
 		MessageContext: interfaces.MessageContext{MessageType: topics.V3Conversation},
 	}
 	if payloadFormat == interfaces.PayloadFormatV4 {
-		req.TopicBytes = topics.TopicToBase64(parsed)
+		req.TopicBytesB64 = topics.TopicToBase64(parsed)
 	}
 	return req
 }
@@ -78,6 +78,6 @@ func Test_ApnsDelivery_BuildNotification_V4TopicBytesB64(t *testing.T) {
 	var p map[string]interface{}
 	require.NoError(t, json.Unmarshal(payloadBytes, &p))
 	require.Equal(t, deliveryTestTopic, p["topic"])
-	require.Equal(t, req.TopicBytes, p["topicBytesB64"])
+	require.Equal(t, req.TopicBytesB64, p["topicBytesB64"])
 	require.Equal(t, "v4", p["payloadFormat"])
 }

--- a/pkg/delivery/fcm.go
+++ b/pkg/delivery/fcm.go
@@ -95,8 +95,8 @@ func buildFcmApnsCustomData(req interfaces.SendRequest, data map[string]string) 
 		"messageType":      data["messageType"],
 		"payloadFormat":    data["payloadFormat"],
 	}
-	if req.TopicBytes != "" {
-		customData["topicBytesB64"] = req.TopicBytes
+	if req.TopicBytesB64 != "" {
+		customData["topicBytesB64"] = req.TopicBytesB64
 	}
 	return customData
 }
@@ -108,8 +108,8 @@ func buildFcmData(req interfaces.SendRequest) map[string]string {
 		"messageType":      string(req.MessageContext.MessageType),
 		"payloadFormat":    req.PayloadFormat.String(),
 	}
-	if req.TopicBytes != "" {
-		data["topicBytesB64"] = req.TopicBytes
+	if req.TopicBytesB64 != "" {
+		data["topicBytesB64"] = req.TopicBytesB64
 	}
 	return data
 }

--- a/pkg/delivery/fcm.go
+++ b/pkg/delivery/fcm.go
@@ -76,12 +76,7 @@ func (f FcmDelivery) Send(ctx context.Context, req interfaces.SendRequest) error
 		APNS: &messaging.APNSConfig{
 			Headers: apnsHeaders,
 			Payload: &messaging.APNSPayload{
-				CustomData: map[string]interface{}{
-					"topic":            req.Topic,
-					"encryptedMessage": data["encryptedMessage"],
-					"messageType":      data["messageType"],
-					"payloadFormat":    data["payloadFormat"],
-				},
+				CustomData: buildFcmApnsCustomData(req, data),
 				Aps: &messaging.Aps{
 					ContentAvailable: req.Subscription.IsSilent,
 					MutableContent:   !req.Subscription.IsSilent,
@@ -93,11 +88,28 @@ func (f FcmDelivery) Send(ctx context.Context, req interfaces.SendRequest) error
 	return err
 }
 
+func buildFcmApnsCustomData(req interfaces.SendRequest, data map[string]string) map[string]interface{} {
+	customData := map[string]interface{}{
+		"topic":            req.Topic,
+		"encryptedMessage": data["encryptedMessage"],
+		"messageType":      data["messageType"],
+		"payloadFormat":    data["payloadFormat"],
+	}
+	if req.TopicBytes != "" {
+		customData["topicBytesB64"] = req.TopicBytes
+	}
+	return customData
+}
+
 func buildFcmData(req interfaces.SendRequest) map[string]string {
-	return map[string]string{
+	data := map[string]string{
 		"topic":            req.Topic,
 		"encryptedMessage": base64.StdEncoding.EncodeToString(req.EncryptedMessage),
 		"messageType":      string(req.MessageContext.MessageType),
 		"payloadFormat":    req.PayloadFormat.String(),
 	}
+	if req.TopicBytes != "" {
+		data["topicBytesB64"] = req.TopicBytes
+	}
+	return data
 }

--- a/pkg/delivery/fcm_test.go
+++ b/pkg/delivery/fcm_test.go
@@ -24,3 +24,12 @@ func Test_BuildFcmData_TopicField(t *testing.T) {
 	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("test")), data["encryptedMessage"])
 	require.Equal(t, "v3-conversation", data["messageType"])
 }
+
+func Test_BuildFcmData_V4TopicBytesB64(t *testing.T) {
+	req := buildDeliveryRequest(t, interfaces.PayloadFormatV4)
+
+	data := buildFcmData(req)
+	require.Equal(t, deliveryTestTopic, data["topic"])
+	require.Equal(t, req.TopicBytes, data["topicBytesB64"])
+	require.Equal(t, "v4", data["payloadFormat"])
+}

--- a/pkg/delivery/fcm_test.go
+++ b/pkg/delivery/fcm_test.go
@@ -30,6 +30,6 @@ func Test_BuildFcmData_V4TopicBytesB64(t *testing.T) {
 
 	data := buildFcmData(req)
 	require.Equal(t, deliveryTestTopic, data["topic"])
-	require.Equal(t, req.TopicBytes, data["topicBytesB64"])
+	require.Equal(t, req.TopicBytesB64, data["topicBytesB64"])
 	require.Equal(t, "v4", data["payloadFormat"])
 }

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -123,6 +123,7 @@ type Subscription struct {
 type SendRequest struct {
 	IdempotencyKey   string         `json:"-"`
 	Topic            string         `json:"-"`
+	TopicBytes       string         `json:"-"`
 	EncryptedMessage []byte         `json:"-"`
 	PayloadFormat    PayloadFormat  `json:"-"`
 	MessageContext   MessageContext `json:"-"`
@@ -142,6 +143,7 @@ type sendRequestJSON struct {
 	Installation   Installation   `json:"installation"`
 	Subscription   Subscription   `json:"subscription"`
 	PayloadFormat  PayloadFormat  `json:"payload_format,omitempty"`
+	TopicBytesB64  string         `json:"topicBytesB64,omitempty"`
 }
 
 func (r SendRequest) MarshalJSON() ([]byte, error) {
@@ -151,6 +153,7 @@ func (r SendRequest) MarshalJSON() ([]byte, error) {
 		Installation:   r.Installation,
 		Subscription:   r.Subscription,
 		PayloadFormat:  r.PayloadFormat,
+		TopicBytesB64:  r.TopicBytes,
 	}
 	out.Message.ContentTopic = r.Topic
 	out.Message.Message = r.EncryptedMessage

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -123,7 +123,7 @@ type Subscription struct {
 type SendRequest struct {
 	IdempotencyKey   string         `json:"-"`
 	Topic            string         `json:"-"`
-	TopicBytes       string         `json:"-"`
+	TopicBytesB64    string         `json:"-"`
 	EncryptedMessage []byte         `json:"-"`
 	PayloadFormat    PayloadFormat  `json:"-"`
 	MessageContext   MessageContext `json:"-"`
@@ -153,7 +153,7 @@ func (r SendRequest) MarshalJSON() ([]byte, error) {
 		Installation:   r.Installation,
 		Subscription:   r.Subscription,
 		PayloadFormat:  r.PayloadFormat,
-		TopicBytesB64:  r.TopicBytes,
+		TopicBytesB64:  r.TopicBytesB64,
 	}
 	out.Message.ContentTopic = r.Topic
 	out.Message.Message = r.EncryptedMessage

--- a/pkg/interfaces/interfaces_test.go
+++ b/pkg/interfaces/interfaces_test.go
@@ -26,6 +26,7 @@ type sendRequestJSONFixture struct {
 	} `json:"message_context"`
 	Topic            string `json:"topic"`
 	EncryptedMessage string `json:"encrypted_message"`
+	TopicBytesB64    string `json:"topicBytesB64"`
 }
 
 func TestPayloadFormat_String(t *testing.T) {
@@ -106,6 +107,48 @@ func TestSendRequest_MarshalJSON_BackwardCompatible(t *testing.T) {
 	require.Empty(t, result.EncryptedMessage)
 	require.Equal(t, "abc123", result.IdempotencyKey)
 	require.Equal(t, "v3-welcome", result.MessageContext.MessageType)
+}
+
+func TestSendRequest_MarshalJSON_TopicBytesIncluded(t *testing.T) {
+	req := SendRequest{
+		IdempotencyKey:   "abc123",
+		Topic:            "/xmtp/mls/1/g-01020304/proto",
+		TopicBytes:       "AQECBA==",
+		EncryptedMessage: []byte("encrypted-data"),
+		PayloadFormat:    PayloadFormatV4,
+		MessageContext:   MessageContext{MessageType: "v3-conversation"},
+	}
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var result sendRequestJSONFixture
+	require.NoError(t, json.Unmarshal(data, &result))
+
+	require.Equal(t, "/xmtp/mls/1/g-01020304/proto", result.Message.ContentTopic)
+	require.Equal(t, "AQECBA==", result.TopicBytesB64)
+}
+
+func TestSendRequest_MarshalJSON_TopicBytesOmittedWhenEmpty(t *testing.T) {
+	req := SendRequest{
+		IdempotencyKey:   "abc123",
+		Topic:            "/xmtp/mls/1/g-01020304/proto",
+		EncryptedMessage: []byte("encrypted-data"),
+		PayloadFormat:    PayloadFormatV3,
+		MessageContext:   MessageContext{MessageType: "v3-conversation"},
+	}
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var result sendRequestJSONFixture
+	require.NoError(t, json.Unmarshal(data, &result))
+
+	require.Empty(t, result.TopicBytesB64)
+	// Also verify it's not in the raw JSON at all
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.NotContains(t, raw, "topicBytesB64")
 }
 
 func Test_Subscription_MarshalJSON_TopicV4NotSerialized(t *testing.T) {

--- a/pkg/interfaces/interfaces_test.go
+++ b/pkg/interfaces/interfaces_test.go
@@ -113,7 +113,7 @@ func TestSendRequest_MarshalJSON_TopicBytesIncluded(t *testing.T) {
 	req := SendRequest{
 		IdempotencyKey:   "abc123",
 		Topic:            "/xmtp/mls/1/g-01020304/proto",
-		TopicBytes:       "AQECBA==",
+		TopicBytesB64:       "AQECBA==",
 		EncryptedMessage: []byte("encrypted-data"),
 		PayloadFormat:    PayloadFormatV4,
 		MessageContext:   MessageContext{MessageType: "v3-conversation"},

--- a/pkg/xmtp/v4_listener.go
+++ b/pkg/xmtp/v4_listener.go
@@ -280,7 +280,8 @@ func buildV4SendRequest(
 
 	return interfaces.SendRequest{
 		IdempotencyKey:   idempotencyKey,
-		Topic:            topics.TopicToBase64(targetTopic),
+		Topic:            topics.TopicToLegacy(targetTopic),
+		TopicBytes:       topics.TopicToBase64(targetTopic),
 		EncryptedMessage: envBytes,
 		PayloadFormat:    interfaces.PayloadFormatV4,
 		MessageContext:   messageContext,

--- a/pkg/xmtp/v4_listener.go
+++ b/pkg/xmtp/v4_listener.go
@@ -281,7 +281,7 @@ func buildV4SendRequest(
 	return interfaces.SendRequest{
 		IdempotencyKey:   idempotencyKey,
 		Topic:            topics.TopicToLegacy(targetTopic),
-		TopicBytes:       topics.TopicToBase64(targetTopic),
+		TopicBytesB64:    topics.TopicToBase64(targetTopic),
 		EncryptedMessage: envBytes,
 		PayloadFormat:    interfaces.PayloadFormatV4,
 		MessageContext:   messageContext,

--- a/pkg/xmtp/v4_listener_test.go
+++ b/pkg/xmtp/v4_listener_test.go
@@ -222,7 +222,8 @@ func TestV4Listener_ProcessGroupMessage_V4Format(t *testing.T) {
 	require.Len(t, sendReqs, 1)
 	capturedReq := testutils.RequireSendRequestForInstallation(t, sendReqs, "inst-v4")
 	require.Equal(t, interfaces.PayloadFormatV4, capturedReq.PayloadFormat)
-	require.Equal(t, topicutil.TopicToBase64(groupTopic), capturedReq.Topic)
+	require.Equal(t, topicutil.TopicToLegacy(groupTopic), capturedReq.Topic)
+	require.Equal(t, topicutil.TopicToBase64(groupTopic), capturedReq.TopicBytes)
 	require.NotEmpty(t, capturedReq.EncryptedMessage)
 	require.Equal(t, topicutil.V3Conversation, capturedReq.MessageContext.MessageType)
 
@@ -296,7 +297,8 @@ func TestV4Listener_ProcessGroupMessage_MixedFormats(t *testing.T) {
 
 	v4Req := testutils.RequireSendRequestForInstallation(t, sendReqs, "inst-mixed-v4")
 	require.Equal(t, interfaces.PayloadFormatV4, v4Req.PayloadFormat)
-	require.Equal(t, topicutil.TopicToBase64(groupTopic), v4Req.Topic)
+	require.Equal(t, topicutil.TopicToLegacy(groupTopic), v4Req.Topic)
+	require.Equal(t, topicutil.TopicToBase64(groupTopic), v4Req.TopicBytes)
 }
 
 // TestV4Listener_SkipNonConvertiblePayload_V3Format tests that a non-group/welcome payload
@@ -365,7 +367,8 @@ func TestV4Listener_DeliverNonConvertiblePayload_V4Format(t *testing.T) {
 	require.Len(t, sendReqs, 1)
 	capturedReq := testutils.RequireSendRequestForInstallation(t, sendReqs, "inst-payer-v4")
 	require.Equal(t, interfaces.PayloadFormatV4, capturedReq.PayloadFormat)
-	require.Equal(t, topicutil.TopicToBase64(payerReportTopic), capturedReq.Topic)
+	require.Equal(t, topicutil.TopicToLegacy(payerReportTopic), capturedReq.Topic)
+	require.Equal(t, topicutil.TopicToBase64(payerReportTopic), capturedReq.TopicBytes)
 	require.Equal(t, topicutil.Unknown, capturedReq.MessageContext.MessageType)
 
 	var deliveredEnv envelopesProto.OriginatorEnvelope

--- a/pkg/xmtp/v4_listener_test.go
+++ b/pkg/xmtp/v4_listener_test.go
@@ -223,7 +223,7 @@ func TestV4Listener_ProcessGroupMessage_V4Format(t *testing.T) {
 	capturedReq := testutils.RequireSendRequestForInstallation(t, sendReqs, "inst-v4")
 	require.Equal(t, interfaces.PayloadFormatV4, capturedReq.PayloadFormat)
 	require.Equal(t, topicutil.TopicToLegacy(groupTopic), capturedReq.Topic)
-	require.Equal(t, topicutil.TopicToBase64(groupTopic), capturedReq.TopicBytes)
+	require.Equal(t, topicutil.TopicToBase64(groupTopic), capturedReq.TopicBytesB64)
 	require.NotEmpty(t, capturedReq.EncryptedMessage)
 	require.Equal(t, topicutil.V3Conversation, capturedReq.MessageContext.MessageType)
 
@@ -298,7 +298,7 @@ func TestV4Listener_ProcessGroupMessage_MixedFormats(t *testing.T) {
 	v4Req := testutils.RequireSendRequestForInstallation(t, sendReqs, "inst-mixed-v4")
 	require.Equal(t, interfaces.PayloadFormatV4, v4Req.PayloadFormat)
 	require.Equal(t, topicutil.TopicToLegacy(groupTopic), v4Req.Topic)
-	require.Equal(t, topicutil.TopicToBase64(groupTopic), v4Req.TopicBytes)
+	require.Equal(t, topicutil.TopicToBase64(groupTopic), v4Req.TopicBytesB64)
 }
 
 // TestV4Listener_SkipNonConvertiblePayload_V3Format tests that a non-group/welcome payload
@@ -368,7 +368,7 @@ func TestV4Listener_DeliverNonConvertiblePayload_V4Format(t *testing.T) {
 	capturedReq := testutils.RequireSendRequestForInstallation(t, sendReqs, "inst-payer-v4")
 	require.Equal(t, interfaces.PayloadFormatV4, capturedReq.PayloadFormat)
 	require.Equal(t, topicutil.TopicToLegacy(payerReportTopic), capturedReq.Topic)
-	require.Equal(t, topicutil.TopicToBase64(payerReportTopic), capturedReq.TopicBytes)
+	require.Equal(t, topicutil.TopicToBase64(payerReportTopic), capturedReq.TopicBytesB64)
 	require.Equal(t, topicutil.Unknown, capturedReq.MessageContext.MessageType)
 
 	var deliveredEnv envelopesProto.OriginatorEnvelope


### PR DESCRIPTION
Resolves https://github.com/xmtp/example-notification-server-go/issues/101

## Summary

- **`buildV4SendRequest`** now sets `Topic` to V3 string format (`TopicToLegacy`) instead of V4 base64 (`TopicToBase64`)
- New `TopicBytes` field on `SendRequest` carries the V4 binary topic as base64
- **APNS**: includes `topicBytesB64` custom field when present
- **FCM**: includes `topicBytesB64` in data map and APNS custom data when present
- **HTTP**: `topicBytesB64` included in JSON via `MarshalJSON` (omitted when empty)
- All existing V3 delivery paths unchanged — `topicBytesB64` only appears for V4 payloads

## Files Changed

| File | Change |
|------|--------|
| `pkg/interfaces/interfaces.go` | Add `TopicBytes` to `SendRequest`, `topicBytesB64` to JSON marshaling |
| `pkg/xmtp/v4_listener.go` | `buildV4SendRequest` uses `TopicToLegacy` for Topic, `TopicToBase64` for TopicBytes |
| `pkg/delivery/apns.go` | Conditionally add `topicBytesB64` to APNS notification payload |
| `pkg/delivery/fcm.go` | Conditionally add `topicBytesB64` to FCM data and APNS custom data |

## Test plan

- [x] `pkg/interfaces` — new tests for TopicBytes JSON marshaling (included + omitted when empty)
- [x] `pkg/delivery` — new V4 tests for APNS and FCM `topicBytesB64` field
- [x] `pkg/xmtp` — updated V4 listener tests assert V3 topic format + TopicBytes field
- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no issues
- [x] Non-DB tests pass (`pkg/interfaces`, `pkg/delivery`, `pkg/topics`)
- [ ] DB-dependent tests (`pkg/xmtp`, `pkg/db`) require PostgreSQL — verified logic changes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `topicBytesB64` field to V4 push notification payloads and set V4 topic to legacy format
> - V4 `SendRequest` now carries both a legacy string `Topic` and a new `TopicBytesB64` field containing the base64-encoded topic bytes, set in [`v4_listener.go`](https://github.com/xmtp/example-notification-server-go/pull/102/files#diff-2f31e94eb448396317dc3ae116f58127af2f7ef3094055e50c5884ccaec3a7d3).
> - `topicBytesB64` is conditionally included in APNS custom payloads and FCM `Data`/`APNS.CustomData` when the field is non-empty.
> - `SendRequest.MarshalJSON` emits `topicBytesB64` in the JSON wire format when set, via the [`interfaces.go`](https://github.com/xmtp/example-notification-server-go/pull/102/files#diff-39167df5487c216e2a95d2be20d452a3a662b510da22a83c32d388ead3c2bffc) custom marshaler.
> - Behavioral Change: V4 `Topic` is now set to the legacy string representation instead of raw topic bytes, which affects downstream consumers reading the `Topic` field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5507525.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->